### PR TITLE
fix: downgrade AdaptiveCard version from `1.5` to `1.4`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1614,7 +1614,7 @@ class MSTeams {
             ...mentionedIds
           ],
           '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
-          version: '1.5',
+          version: '1.4',
           msteams: {
             entities: entities
           }

--- a/src/MSTeams.js
+++ b/src/MSTeams.js
@@ -261,7 +261,7 @@ class MSTeams {
             ...mentionedIds
           ],
           '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
-          version: '1.5',
+          version: '1.4',
           msteams: {
             entities: entities
           }


### PR DESCRIPTION
## Description
downgrade AdaptiveCard version from `1.5` to `1.4`

## Related PRs
- Skitionek/notify-microsoft-teams/pull/96